### PR TITLE
homepage: remove trailing slash on openbuildservice link

### DIFF
--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -229,7 +229,7 @@ aboutProduct2:
       button:
         enable : true
         label : "openSUSE Build Service Help"
-        link : "https://en.opensuse.org/Portal:Packaging/"
+        link : "https://en.opensuse.org/Portal:Packaging"
 
     # about product item loop
     - image : "images/packaging/snapcraft.png"


### PR DESCRIPTION
Otherwise this navigates to a missing wiki page.